### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ make
 lua client.lua login 80 1
 ```
 
-##About skynet
+## About skynet
 [https://github.com/cloudwu/skynet](https://github.com/cloudwu/skynet)<br /> 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
